### PR TITLE
Add type asserts to `bio_get_data`

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -41,9 +41,8 @@ function on_bio_stream_read(bio::BIO, out::Ptr{Cchar}, outlen::Cint)
             bio_set_read_retry(bio)
             return Cint(0)
         end
-        outlen = min(outlen, n)
-        unsafe_read(io, out, outlen)
-        return Cint(outlen)
+        unsafe_read(io, out, min(UInt(n), outlen))
+        return Cint(min(n, outlen))
     catch e
         # we don't want to throw a Julia exception from a C callback
         return Cint(0)

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -35,7 +35,7 @@ bio_clear_flags(bio::BIO) = bio_set_flags(bio, 0x00)
 function on_bio_stream_read(bio::BIO, out::Ptr{Cchar}, outlen::Cint)
     try
         bio_clear_flags(bio)
-        io = bio_get_data(bio)
+        io = bio_get_data(bio)::TCPSocket
         n = bytesavailable(io)
         if n == 0
             bio_set_read_retry(bio)
@@ -52,7 +52,7 @@ end
 
 function on_bio_stream_write(bio::BIO, in::Ptr{Cchar}, inlen::Cint)::Cint
     try
-        io = bio_get_data(bio)
+        io = bio_get_data(bio)::TCPSocket
         written = unsafe_write(io, in, inlen)
         return Cint(written)
     catch e
@@ -639,7 +639,7 @@ function Base.close(ssl::SSLStream, shutdown::Bool=true)
         end
         finalize(ssl.ssl)
     end
-    return 
+    return
 end
 
 """

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -51,7 +51,7 @@ end
 
 function on_bio_stream_write(bio::BIO, in::Ptr{Cchar}, inlen::Cint)::Cint
     try
-        io = bio_get_data(bio)::TCPSocket
+        io = bio_get_data(bio)
         written = unsafe_write(io, in, inlen)
         return Cint(written)
     catch e


### PR DESCRIPTION
This helps with allocations in `on_bio_stream_read`. There are still some remaining allocations, one of which is allocation an `UInt64`, possibly to store the 64 bit version of `outlen` which is required by `unsafe_read` method signature.

Do we want to support `UDPSockets` as well?