### PR TITLE
Summary of changes in this commit:

### DIFF
--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -2931,15 +2931,19 @@ function get_error()::String
     # Read the formatted error messages from the memory BIO.
 
     # Ensure the queue is clear (if ERR_print_errors fails).
-    ccall(
-        (:ERR_clear_error, libcrypto),
-        Cvoid,
-        ())
+    clear_errors!()
 
     # Free bio.
     free(bio)
 
     return error_msg
+end
+
+function clear_errors!()
+    ccall(
+        (:ERR_clear_error, libcrypto),
+        Cvoid,
+        ())
 end
 
 function OpenSSLError(ret::Integer)

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -556,6 +556,8 @@ end
 function Base.unsafe_read(ssl::SSLStream, buf::Ptr{UInt8}, nbytes::UInt)
     nread = 0
     while nread < nbytes
+        # If open, optimistically call `SSL_read_ex` to try to save an `eof` call;
+        # if that returns `SSL_WANT_READ` we will call `eof` anyway afterwards.
         !isopen(ssl) && throw(EOFError())
         readbytes = ssl.readbytes
         @geterror ccall(


### PR DESCRIPTION
  * Factor ERR_clear_error into its own function and call in the geterror macro right before we do SSL IO operations; the openssl docs recommend this and trying to keep your error stack as clean as possible
  * Add :acquire/:release memory orderings to our atomic operations; shouldn't make that big of a difference, but more semantically correct with how we define our atomicget/atomicset macros
  * Instead of call `eof(ssl)` before each SSL_read_ex call, we instead only check that the ssl is open, then optimistically call SSL_read_ex; if there are buffered bytes, they'll be processed and we saved ourselves an `eof` call; if SSL_read_ex returns SSL_WANT_READ, then we'll call `eof` anyway afterwards
  * Remove the finalizer on our SSL struct; @kpamnany recommended avoiding finalizers and we already have really well defined create/destroy moments for SSLs, so we don't need to be messing w/ the global finalizer list
  * Remove 2 `update_tls_error_state` calls in SSL_pending and SSL_has_pending; these aren't needed because the openssl documentation mentions specifically these don't use the same error reporting as IO functions
  * Also tweaked our eof call to avoid allocating a Ref{UInt8} each time it is called