### PR TITLE
OpenSSL v3 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,7 +64,7 @@ jobs:
           try
             Pkg.add(PackageSpec(name="OpenSSL_jll", version="1.1"))
             Pkg.develop(PackageSpec(path="."))
-            Pkg.test()  # resolver may fail with test time deps
+            Pkg.test("OpenSSL")  # resolver may fail with test time deps
           catch err
             err isa Pkg.Resolve.ResolverError || rethrow()
             # If we can't resolve that means this is incompatible by SemVer and this is fine;

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,9 @@ jobs:
         run: |
           using Pkg
           try
-            Pkg.add(PackageSpec(name="OpenSSL_jll", version="1.1"))
+            spec = PackageSpec(name="OpenSSL_jll", version="1.1")
+            Pkg.add(spec)
+            Pkg.pin(spec)
             Pkg.develop(PackageSpec(path="."))
             Pkg.test("OpenSSL")  # resolver may fail with test time deps
           catch err

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,22 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - name: Test with OpenSSL v1.1
+        shell: julia --project=openssl_1_1 {0}
+        run: |
+          using Pkg
+          try
+            Pkg.add(PackageSpec(name="OpenSSL_jll", version="1.1"))
+            Pkg.develop(PackageSpec(path="."))
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine;
+            # it means we marked this as a breaking change, so we don't need to worry about
+            # mistakenly introducing a breaking change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately as a success.
+          end
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -52,3 +52,20 @@ jobs:
             @info "Not compatible with this release. No problem." exception=err
             exit(0)  # Exit immediately as a success.
           end
+      - name: Run downstream tests with OpenSSL v1.1
+        shell: julia --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # Force downstream tests to use this PR's version of the package.
+            Pkg.add(PackageSpec(name="OpenSSL_jll", version="1.1"))
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine;
+            # it means we marked this as a breaking change, so we don't need to worry about
+            # mistakenly introducing a breaking change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately as a success.
+          end

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -31,7 +31,7 @@ jobs:
           arch: x64
       - uses: julia-actions/julia-buildpkg@latest
       - name: Clone Downstream
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream

--- a/.github/workflows/IntegrationTest_OpenSSL_v1_1.yml
+++ b/.github/workflows/IntegrationTest_OpenSSL_v1_1.yml
@@ -41,7 +41,9 @@ jobs:
           using Pkg
           try
             # Force downstream tests to use this PR's version of the package.
-            Pkg.add(PackageSpec(name="OpenSSL_jll", version="1.1"))
+            spec = PackageSpec(name="OpenSSL_jll", version="1.1")
+            Pkg.add(spec)
+            Pkg.pin(spec)
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
             Pkg.update()
             Pkg.test()  # resolver may fail with test time deps

--- a/.github/workflows/IntegrationTest_OpenSSL_v1_1.yml
+++ b/.github/workflows/IntegrationTest_OpenSSL_v1_1.yml
@@ -1,4 +1,4 @@
-name: IntegrationTest
+name: IntegrationTestOpenSSL_v1_1
 on:
   push:
     branches: [main]
@@ -35,12 +35,13 @@ jobs:
         with:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
-      - name: Load this and run the downstream tests
+      - name: Load this and run the downstream tests with OpenSSL v1.1
         shell: julia --project=downstream {0}
         run: |
           using Pkg
           try
             # Force downstream tests to use this PR's version of the package.
+            Pkg.add(PackageSpec(name="OpenSSL_jll", version="1.1"))
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
             Pkg.update()
             Pkg.test()  # resolver may fail with test time deps

--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,10 @@ OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-julia = "1.6"
 BitFlags = "0.1"
 MozillaCACerts_jll = ">= 2020"
-OpenSSL_jll = "1.1"
+OpenSSL_jll = "1.1, 3.0"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -38,7 +38,6 @@ const Option{T} = Union{Nothing,T} where {T}
 const HTTP2_ALPN = "\x02h2"
 const UPDATE_HTTP2_ALPN = "\x02h2\x08http/1.1"
 
-
 """
     These are used in the following macros and are passed to BIO_ctrl().
 """

--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -466,6 +466,14 @@ struct OpenSSLError <: Exception
     OpenSSLError(x::SSLErrorCode) = new(string(x))
 end
 
+"""
+    version(; [version_type::OpenSSLVersion])
+
+Obtain the version as a `String`. See [`OpenSSLVersion`](@ref) to select
+the version type.
+
+See also [`version_number`](@ref) to obtain a `VersionNumber`.
+"""
 function version(; version_type::OpenSSLVersion=OPENSSL_VERSION)::String
     version = ccall(
         (:OpenSSL_version, libcrypto),

--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -540,15 +540,21 @@ OpenSSL v3 is used.
 !!! compat "OpenSSL v3" `ossl_provider_set_default_search_path` is only available with version 3 of the OpenSSL_jll
 """
 function ossl_provider_set_default_search_path(libctx = C_NULL, path = joinpath(dirname(OpenSSL_jll.libssl), "ossl-modules"))
-    result = ccall(
-        (:OSSL_PROVIDER_set_default_search_path, libssl),
-        Cint,
-        (Ptr{Nothing}, Cstring),
-        libctx,
-        path
-    )
-    if result == 0
-        throw(OpenSSLError())
+    @static if Sys.iswindows()
+        # TODO: Figure out why OSSL_PROVIDER_set_default_search_path is missing
+        ENV["OPENSSL_MODULES"] = joinpath(dirname(OpenSSL_jll.libssl), "ossl-modules")
+        result = 1
+    else
+        result = ccall(
+            (:OSSL_PROVIDER_set_default_search_path, libssl),
+            Cint,
+            (Ptr{Nothing}, Cstring),
+            libctx,
+            path
+        )
+        if result == 0
+            throw(OpenSSLError())
+        end
     end
     return result
 end

--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -524,7 +524,7 @@ function _ossl_modules_path()
     @static if Sys.iswindows()
         bin_dir = dirname(OpenSSL_jll.libssl_path)
         lib_dir = joinpath(dirname(bin_dir), "lib")
-        if Sys.WORD == 64
+        if Sys.WORD_SIZE == 64
             return joinpath(lib_dir * "64", "ossl-modules")
         else
             return joinpath(lib_dir, "ossl-modules")

--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -45,16 +45,24 @@ Return the version number of the OpenSSL C library.
 This uses `OpenSSL_version_num()`.
 """
 function version_number()
-    # This works on OpenSSL v1.1
-    vn = ccall((:OpenSSL_version_num, libssl), Culong, ())
+    @static if Sys.iswindows()
+        # Windows cannot find OpenSSL_version_num symbol ??
+        m = match(r"OpenSSL (\d+)\.(\d+)\.(\d+)", OpenSSL.version())
+        major = parse(Int, m[1])
+        minor = parse(Int, m[2])
+        patch = parse(Int, m[3])
+    else
+        # This works on OpenSSL v1.1
+        vn = ccall((:OpenSSL_version_num, libssl), Culong, ())
 
-    # 0xMNN00PP0L
-    # M: major
-    # NN: minor
-    # PP: patch
-    major = vn >> 28
-    minor = vn >> 20 & 0xff
-    patch = vn >> 4 & 0xff
+        # 0xMNN00PP0L
+        # M: major
+        # NN: minor
+        # PP: patch
+        major = vn >> 28
+        minor = vn >> 20 & 0xff
+        patch = vn >> 4 & 0xff
+    end
 
     return VersionNumber(major, minor, patch)
 end

--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -519,6 +519,21 @@ else
     const EVP_CIPHER_CTX_iv_length = :EVP_CIPHER_CTX_iv_length
 end
 
+# Locate oss-modules, which contains legacy shared library
+function _ossl_modules_path()
+    @static if Sys.iswindows()
+        bin_dir = dirname(OpenSSL_jll.libssl_path)
+        lib_dir = joinpath(dirname(bin_dir), "lib")
+        if Sys.WORD == 64
+            return joinpath(lib_dir * "64", "ossl-modules")
+        else
+            return joinpath(lib_dir, "ossl-modules")
+        end
+    else
+        return joinpath(dirname(OpenSSL_jll.libssl), "ossl-modules")
+    end
+end
+
 """
     ossl_provider_set_default_search_path([libctx], [path])
 
@@ -531,7 +546,7 @@ OpenSSL v3 is used.
 
 !!! compat "OpenSSL v3" `ossl_provider_set_default_search_path` is only available with version 3 of the OpenSSL_jll
 """
-function ossl_provider_set_default_search_path(libctx = C_NULL, path = joinpath(dirname(OpenSSL_jll.libssl), "ossl-modules"))
+function ossl_provider_set_default_search_path(libctx = C_NULL, path = _ossl_modules_path())
     result = ccall(
         (:OSSL_PROVIDER_set_default_search_path, libcrypto),
         Cint,

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -700,7 +700,7 @@ end
 """
 function get_peer_certificate(ssl::SSLStream)::Option{X509Certificate}
     x509 = ccall(
-        (:SSL_get_peer_certificate, libssl),
+        (SSL_get_peer_certificate, libssl),
         Ptr{Cvoid},
         (SSL,),
         ssl.ssl)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -607,12 +607,20 @@ end
 @testset "VersionNumber" begin
     vn = OpenSSL.version_number()
     @test vn ≥ v"1.1"
+
+    m = match(r"OpenSSL (\d+)\.(\d+)\.(\d+)", OpenSSL.version())
+    major = parse(Int, m[1])
+    minor = parse(Int, m[2])
+    patch = parse(Int, m[3])
+    vn2 = VersionNumber(major, minor, patch)
+    @test vn == vn2
+
     if vn ≥ v"3"
         # These only work with OpenSSL v3
         major = ccall((:OPENSSL_version_major, libcrypto), Cuint, ())
         minor = ccall((:OPENSSL_version_minor, libcrypto), Cuint, ())
         patch = ccall((:OPENSSL_version_patch, libcrypto), Cuint, ())
-        vn2 = VersionNumber(major, minor, patch)
-        @test vn == vn2
+        vn3 = VersionNumber(major, minor, patch)
+        @test vn == vn3
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -388,7 +388,7 @@ end
     ssl_ctx = OpenSSL.SSLContext(OpenSSL.TLSServerMethod())
 
     # Make direct invalid call to OpenSSL
-    invalid_cipher_suites = "TLS_AES_356_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+    invalid_cipher_suites = "TLS_AES_356_GCM_SHA384"
     result = ccall(
         (:SSL_CTX_set_ciphersuites, libssl),
         Cint,
@@ -454,13 +454,17 @@ end
     @test _x509_certificate.issuer_name == x509_certificate.issuer_name
 end
 
+# https://www.openssl.org/docs/man3.0/man7/OSSL_PROVIDER-legacy.html
 @testset "Encrypt" begin
+    if OpenSSL.version_number() ≥ v"3"
+        OpenSSL.load_legacy_provider()
+    end
     evp_ciphers = [
         EvpEncNull(),
-        EvpBlowFishCBC(),
-        EvpBlowFishECB(),
+        EvpBlowFishCBC(), # legacy
+        EvpBlowFishECB(), # legacy
         #EvpBlowFishCFB(), // not supported
-        EvpBlowFishOFB(),
+        EvpBlowFishOFB(), # legacy
         EvpAES128CBC(),
         EvpAES128ECB(),
         #EvpAES128CFB(), // not supported
@@ -496,6 +500,10 @@ end
 end
 
 @testset "EncryptCustomKey" begin
+    # EvpBlowFishECB is legacy, consider using EvpAES128ECB instead
+    if OpenSSL.version_number() ≥ v"3"
+        OpenSSL.load_legacy_provider()
+    end
     evp_cipher = EvpBlowFishECB()
     sym_key = random_bytes(evp_cipher.key_length ÷ 2)
     init_vector = random_bytes(evp_cipher.init_vector_length ÷ 2)
@@ -593,5 +601,18 @@ end
     if isdefined(Base, :errormonitor)
         errormonitor(server_task)
         errormonitor(client_task)
+    end
+end
+
+@testset "VersionNumber" begin
+    vn = OpenSSL.version_number()
+    @test vn ≥ v"1.1"
+    if vn ≥ v"3"
+        # These only work with OpenSSL v3
+        major = ccall((:OPENSSL_version_major, libssl), Cuint, ())
+        minor = ccall((:OPENSSL_version_minor, libssl), Cuint, ())
+        patch = ccall((:OPENSSL_version_patch, libssl), Cuint, ())
+        vn2 = VersionNumber(major, minor, patch)
+        @test vn == vn2
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -613,7 +613,13 @@ end
     minor = parse(Int, m[2])
     patch = parse(Int, m[3])
     vn2 = VersionNumber(major, minor, patch)
-    @test vn == vn2
+    if vn < v"3"
+        # OpenSSL v1.1 uses non-conventional version numbers
+        @test vn.major == vn2.major
+        @test vn.minor == vn2.minor
+    else
+        @test vn == vn2
+    end
 
     if vn ≥ v"3"
         # These only work with OpenSSL v3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -609,9 +609,9 @@ end
     @test vn ≥ v"1.1"
     if vn ≥ v"3"
         # These only work with OpenSSL v3
-        major = ccall((:OPENSSL_version_major, libssl), Cuint, ())
-        minor = ccall((:OPENSSL_version_minor, libssl), Cuint, ())
-        patch = ccall((:OPENSSL_version_patch, libssl), Cuint, ())
+        major = ccall((:OPENSSL_version_major, libcrypto), Cuint, ())
+        minor = ccall((:OPENSSL_version_minor, libcrypto), Cuint, ())
+        patch = ccall((:OPENSSL_version_patch, libcrypto), Cuint, ())
         vn2 = VersionNumber(major, minor, patch)
         @test vn == vn2
     end


### PR DESCRIPTION
This adds support for OpenSSL v3.0 via OpenSSL_jll v3.0.8

We should configure CI to test against both OpenSSL v1.1 and OpenSSL v3