### PR TITLE
fix some runtime calls reported by JET

### DIFF
--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -529,7 +529,7 @@ end
 # Locate oss-modules, which contains legacy shared library
 function _ossl_modules_path()
     @static if Sys.iswindows()
-        bin_dir = dirname(OpenSSL_jll.libssl_path)
+        bin_dir = dirname(OpenSSL_jll.libssl_path::String)
         lib_dir = joinpath(dirname(bin_dir), "lib")
         if Sys.WORD_SIZE == 64
             return joinpath(lib_dir * "64", "ossl-modules")
@@ -537,7 +537,7 @@ function _ossl_modules_path()
             return joinpath(lib_dir, "ossl-modules")
         end
     else
-        return joinpath(dirname(OpenSSL_jll.libssl), "ossl-modules")
+        return joinpath(dirname(OpenSSL_jll.libssl::String), "ossl-modules")
     end
 end
 

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -14,7 +14,7 @@ function bio_get_data(bio::BIO)
         Ptr{Cvoid},
         (BIO,),
         bio)
-    return unsafe_pointer_to_objref(data)
+    return unsafe_pointer_to_objref(data)::IO
 end
 
 const BIO_FLAGS_SHOULD_RETRY = 0x08
@@ -52,7 +52,7 @@ end
 function on_bio_stream_write(bio::BIO, in::Ptr{Cchar}, inlen::Cint)::Cint
     try
         io = bio_get_data(bio)
-        written = unsafe_write(io, in, inlen)
+        written = unsafe_write(io, in, inlen)::Int
         return Cint(written)
     catch e
         # we don't want to throw a Julia exception from a C callback


### PR DESCRIPTION
I saw some slowdowns in package loading (not huge but measureable) from `OpenSSL.__init__` getting recompiled due to it getting invalidated. I used JET and tried to fix up some simple stuff. Don't actually know how much effect this will have in practice..