### PR TITLE
Fix `adjust` not defined in `Main`

### DIFF
--- a/test/http_helpers.jl
+++ b/test/http_helpers.jl
@@ -13,8 +13,8 @@ function test_server()
     add_entry(x509_name, "ST", "Isles of Redmond")
     add_entry(x509_name, "CN", "www.redmond.com")
 
-    adjust(x509_certificate.time_not_before, Second(0))
-    adjust(x509_certificate.time_not_after, Year(1))
+    Dates.adjust(x509_certificate.time_not_before, Second(0))
+    Dates.adjust(x509_certificate.time_not_after, Year(1))
 
     x509_certificate.subject_name = x509_name
     x509_certificate.issuer_name = x509_name


### PR DESCRIPTION
Follow #33

test with: Julia Version 1.12.0-DEV.302 (OpenSSL-branch)

```
Test Summary: | Unhandled Task ERROR: UndefVarError: `adjust` not defined in `Main`
Stacktrace:
 [1] test_server()
   @ Main C:\Users\inkyd\.julia\packages\OpenSSL\hXs2T\test\http_helpers.jl:16
 [2] (::var"#21#23")()
   @ Main C:\Users\inkyd\.julia\packages\OpenSSL\hXs2T\test\runtests.jl:573
```
