### PR TITLE
Add `version` property to `X509Request`. Various test fixes. Update CI. 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
           - 'nightly'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
             arch: x86
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
           - macOS-latest
           - windows-latest
         arch:
-          - x64
+          - 'default'
         include:
           - os: windows-latest
             version: '1'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
@@ -45,16 +45,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - name: Test with OpenSSL v1.1

--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -2668,6 +2668,22 @@ function set_public_key(x509_req::X509Request, evp_pkey::EvpPKey)
     end
 end
 
+function set_version(x509_req::X509Request, version::Int)
+    if ccall(
+        (:X509_REQ_set_version, libcrypto),
+        Cint,
+        (X509Request, Cint),
+        x509_req,
+        version) != 1
+        throw(OpenSSLError())
+    end
+end
+
+function get_version(x509_req::X509Request)::Int
+    version = ccall((:X509_REQ_get_version, libcrypto), Clong, (X509Request,), x509_req)
+    return Int(version)
+end
+
 function get_extensions(x509_req::X509Request)
     sk = ccall(
         (:X509_REQ_get_extensions, libcrypto),
@@ -2688,6 +2704,8 @@ function Base.getproperty(x509_req::X509Request, name::Symbol)
         return get_public_key(x509_req)
     elseif name === :extensions
         return get_extensions(x509_req)
+    elseif name === :version
+        return get_version(x509_req)
     else
         # fallback to getfield
         return getfield(x509_req, name)
@@ -2699,6 +2717,8 @@ function Base.setproperty!(x509_req::X509Request, name::Symbol, value)
         set_subject_name(x509_req, value)
     elseif name === :public_key
         set_public_key(x509_req, value)
+    elseif name === :version
+        set_version(x509_req, value)
     else
         # fallback to setfield
         setfield!(x509_req, name, value)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -572,8 +572,9 @@ end
 end
 
 @testset "SSLServer" begin
-    server_task = @async test_server()
-    client_task = @async test_client()
+    server_ready = Threads.Condition()
+    server_task = @async test_server(server_ready)
+    client_task = @async test_client(server_ready)
     if isdefined(Base, :errormonitor)
         errormonitor(server_task)
         errormonitor(client_task)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,7 +187,7 @@ end
 
     x509_server_cert = OpenSSL.get_peer_certificate(ssl)
 
-    @test String(x509_server_cert.issuer_name) == "/C=US/O=Let's Encrypt/CN=R3"
+    @test String(x509_server_cert.issuer_name) == "/C=US/O=Let's Encrypt/CN=R11"
     @test String(x509_server_cert.subject_name) == "/CN=httpbingo.julialang.org"
 
     request_str = "GET /status/200 HTTP/1.1\r\nHost: httpbingo.julialang.org\r\nUser-Agent: curl\r\nAccept: */*\r\n\r\n"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -340,6 +340,7 @@ end
     # Create a certificate sign request.
     x509_request = X509Request()
     x509_request.version = 0
+    @test x509_request.version == 0
 
     evp_pkey = EvpPKey(rsa_generate_key())
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -339,6 +339,7 @@ end
 
     # Create a certificate sign request.
     x509_request = X509Request()
+    x509_request.version = 0
 
     evp_pkey = EvpPKey(rsa_generate_key())
 


### PR DESCRIPTION
- Update CI
- Add dependabot
- Update Let's encrypt CN in tests
- Adds and sets :version property of X509Request version to fix cert failure (should probably be a minor bump)
- Adds orchestration to server-client tests to prevent race