### PR TITLE
Update tagbot.yml permissions

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -4,6 +4,22 @@ on:
     types:
       - created
   workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
It looks like the tagbot action might not be working on this repo because of permissions. I see you tagged and registered v1.5.0 but tagbot has not created a github release for it. This PR adds permissions to the tagbot.yml file following the format from SciML (see [here](https://github.com/SciML/DataInterpolations.jl/blob/master/.github/workflows/TagBot.yml) for example). Hopefully this will get your tagbot action working.