### PR TITLE
Remove IO from close function

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -686,7 +686,7 @@ function Base.close(ssl::SSLStream, shutdown::Bool=true)
             try
                 ssl_disconnect(ssl.ssl)
             catch err
-                @debug "SSL disconnect failed" err
+                ccall(:jl_safe_printf, Cvoid, (Cstring, Cstring), "SSL disconnect failed %s.", repr(err))
             end
         end
         free(ssl.ssl)


### PR DESCRIPTION
This function is called from the finalizer as of https://github.com/JuliaWeb/OpenSSL.jl/commit/74ce7df91f28ae5618f834488f8e3e5dd2ae30a6


Tentative fix for https://github.com/JuliaWeb/OpenSSL.jl/issues/44 but I'm not 100% sure that's enough. But hopefully this helps. 