### PR TITLE
Fix tests for package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenSSL"
 uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
-authors = ["Greg Lapinski <grzegorz.lapinski@live.com>", "Jacob Quinn <quinn.jacobd@gmail.com>"]
 version = "1.5.0"
+authors = ["Greg Lapinski <grzegorz.lapinski@live.com>", "Jacob Quinn <quinn.jacobd@gmail.com>"]
 
 [deps]
 BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
@@ -14,10 +14,12 @@ Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 BitFlags = "0.1"
 MozillaCACerts_jll = ">= 2020"
 OpenSSL_jll = "1.1, 3.0"
+TimeZones = "1.22.1"
 julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [targets]
-test = ["Test"]
+test = ["Test", "TimeZones"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,7 +187,7 @@ end
 
     x509_server_cert = OpenSSL.get_peer_certificate(ssl)
 
-    @test String(x509_server_cert.issuer_name) == "/C=US/O=Let's Encrypt/CN=R11"
+    @test occursin("/C=US/O=Let's Encrypt", String(x509_server_cert.issuer_name))
     @test String(x509_server_cert.subject_name) == "/CN=httpbingo.julialang.org"
 
     request_str = "GET /status/200 HTTP/1.1\r\nHost: httpbingo.julialang.org\r\nUser-Agent: curl\r\nAccept: */*\r\n\r\n"


### PR DESCRIPTION
1. The cert for `httpbingo.julialang.org` had changed from  `/C=US/O=Let's Encrypt/CN=R11`  to  `C=US/O=Let's Encrypt/CN=R12` . Make the tests robust to these changes. 

2. The Mozilla CA certificate file had been updated in Julia 1.12. The tests were assuming the second certificate in that file was a GlobaSign CA, which can obviously change for each version of that file.  Now, the test do not assume a fixed cert, just checks that the certificate is parsed to reasonable values. 