### PR TITLE
Remove use of at-async in SSLStream close

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -682,16 +682,10 @@ function Base.close(ssl::SSLStream, shutdown::Bool=true)
     Base.@lock ssl.lock begin
         ssl.closed && return
         ssl.closed = true
-        if shutdown
-            try
-                ssl_disconnect(ssl.ssl)
-            catch err
-                @debug "SSL disconnect failed" err
-            end
-        end
+        shutdown && ssl_disconnect(ssl.ssl)
         free(ssl.ssl)
     end
-    @async try
+    try
         Base.close(ssl.io)
     catch e
         e isa Base.IOError || rethrow()


### PR DESCRIPTION
Should fix #44. I can't quite remember why we called at-async from close to close the underlying IO, but it shouldn't make that much of a difference to run this inline w/o at-async and makes this not cause problems when run in finalizers.