### PR TITLE
Use CA configuration from NetworkOptions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OpenSSL"
 uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
-version = "1.5.0"
+version = "1.6.0"
 authors = ["Greg Lapinski <grzegorz.lapinski@live.com>", "Jacob Quinn <quinn.jacobd@gmail.com>"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ authors = ["Greg Lapinski <grzegorz.lapinski@live.com>", "Jacob Quinn <quinn.jac
 BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 MozillaCACerts_jll = "14a3606d-f60d-562e-9121-12d972cd8159"
+NetworkOptions = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 

--- a/src/OpenSSL.jl
+++ b/src/OpenSSL.jl
@@ -5,6 +5,7 @@ using Dates
 using OpenSSL_jll
 using Sockets
 using MozillaCACerts_jll
+using NetworkOptions: NetworkOptions
 
 """
     [x] Encryption, decryption


### PR DESCRIPTION
This patch uses CA configuration from NetworkOptions instead of directly using the certificates from MozillaCACerts_jll. The benefits are:
 - On Linux machines this will use system configured certificates which are typically kept up to date using the package manager or similar.
 - The default can be overwridden using environment variables (see NetworkOptions README).

Fixes #37, fixes https://github.com/JuliaWeb/HTTP.jl/issues/1239.