### PR TITLE
fix: throw error instead of assertion for CA config read failure

### DIFF
--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -162,7 +162,9 @@ mutable struct SSLContext
             ssl_context, 33, SSL_MODE_AUTO_RETRY, C_NULL)
         if !isempty(verify_file)
             ret = ca_chain!(ssl_context, verify_file)
-            @assert ret == 1
+            if ret != 1
+                error("Failed to load system CA configuration.")
+            end
         end
 
         return ssl_context

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -163,7 +163,7 @@ mutable struct SSLContext
         if !isempty(verify_file)
             ret = ca_chain!(ssl_context, verify_file)
             if ret != 1
-                error("Failed to load system CA configuration at '$(verify_file)'.")
+                error("Failed to validate CA certificates at '$(verify_file)'.")
             end
         end
 

--- a/src/ssl.jl
+++ b/src/ssl.jl
@@ -163,7 +163,7 @@ mutable struct SSLContext
         if !isempty(verify_file)
             ret = ca_chain!(ssl_context, verify_file)
             if ret != 1
-                error("Failed to load system CA configuration.")
+                error("Failed to load system CA configuration at '$(verify_file)'.")
             end
         end
 


### PR DESCRIPTION
Makes the error reporting for that code path a bit more obvious. In light of https://github.com/JuliaWeb/OpenSSL.jl/issues/54, we could also mention the env vars here?